### PR TITLE
Add skeleton Llama PDF extraction extension

### DIFF
--- a/extensions/llama-pdf-extract/README.md
+++ b/extensions/llama-pdf-extract/README.md
@@ -1,0 +1,12 @@
+# Llama PDF Extract Extension
+
+This Directus extension exposes an endpoint for parsing PDF files with the
+`llama-extract` library. The parsed content can then be used as the body of a
+Directus article.
+
+The `/extract` route accepts a `multipart/form-data` request containing a `file`
+field with the PDF. The response returns the extracted HTML.
+
+The actual integration with `llama-extract` is left as a TODO. Replace the
+placeholder implementation in `src/index.ts` with real logic once the library is
+available in this environment.

--- a/extensions/llama-pdf-extract/package.json
+++ b/extensions/llama-pdf-extract/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "llama-pdf-extract",
+  "description": "Extract PDF content with Llama Extract for Directus articles",
+  "icon": "description",
+  "version": "1.0.0",
+  "keywords": [
+    "directus",
+    "directus-extension",
+    "directus-extension-endpoint"
+  ],
+  "type": "module",
+  "files": [
+    "dist"
+  ],
+  "directus:extension": {
+    "type": "endpoint",
+    "source": "src/index.ts",
+    "path": {
+      "api": "dist/index.js"
+    },
+    "host": "^10.10.0"
+  },
+  "scripts": {
+    "build": "directus-extension build",
+    "dev": "directus-extension build -w --no-minify",
+    "link": "directus-extension link",
+    "validate": "directus-extension validate"
+  },
+  "devDependencies": {
+    "@directus/extensions-sdk": "13.1.0",
+    "typescript": "^5.8.3"
+  },
+  "dependencies": {
+    "multer": "^1.4.5-lts.2"
+  }
+}

--- a/extensions/llama-pdf-extract/src/index.ts
+++ b/extensions/llama-pdf-extract/src/index.ts
@@ -1,0 +1,28 @@
+import { defineEndpoint } from '@directus/extensions-sdk';
+import { Request, Response } from 'express';
+import multer from 'multer';
+
+// Placeholder import for llama-extract. Assumes a function that accepts a file path
+// and returns extracted HTML or text content.
+// TODO: Replace with actual llama-extract import when available.
+// import { extract } from 'llama-extract';
+
+const upload = multer({ storage: multer.memoryStorage() });
+
+export default defineEndpoint((router) => {
+  router.post('/extract', upload.single('file'), async (req: Request, res: Response) => {
+    if (!req.file) {
+      return res.status(400).json({ status: 'error', message: 'No PDF uploaded' });
+    }
+
+    try {
+      // TODO: Use llama-extract to parse the uploaded PDF buffer.
+      // const result = await extract(req.file.buffer);
+      const result = '<p>TODO: parsed content from llama-extract</p>';
+
+      res.json({ status: 'ok', data: { html: result } });
+    } catch (error: any) {
+      res.status(500).json({ status: 'error', message: error.message });
+    }
+  });
+});

--- a/extensions/llama-pdf-extract/tsconfig.json
+++ b/extensions/llama-pdf-extract/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "lib": ["ES2019", "DOM"],
+    "moduleResolution": "node",
+    "strict": true,
+    "noFallthroughCasesInSwitch": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "noImplicitAny": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "noUnusedLocals": true,
+    "noUncheckedIndexedAccess": true,
+    "noUnusedParameters": true,
+    "alwaysStrict": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "resolveJsonModule": false,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "rootDir": "./src"
+  },
+  "include": ["./src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- add `llama-pdf-extract` extension with endpoint skeleton
- document how the endpoint will accept PDF uploads
- placeholder TODO for using `llama-extract`

## Testing
- `git status --short`
