### PR TITLE
Use Directus services for PDF extraction

### DIFF
--- a/extensions/llama-pdf-extract/src/types/directus.d.ts
+++ b/extensions/llama-pdf-extract/src/types/directus.d.ts
@@ -1,4 +1,3 @@
-import { Knex } from 'knex';
 
 // Extend Express Request interface to include Directus accountability
 declare global {
@@ -29,7 +28,10 @@ declare global {
 }
 
 export interface DirectusServices {
-  FilesService: new (options: { knex: Knex; accountability?: any }) => {
+  FilesService: new (options: { schema: any; accountability?: any }) => {
     readOne: (id: string, options?: { stream?: boolean }) => Promise<any>;
+  };
+  AssetsService: new (options: { schema: any; accountability?: any }) => {
+    getAsset: (id: string) => Promise<{ stream: NodeJS.ReadableStream }>;
   };
 }


### PR DESCRIPTION
## Summary
- simplify `llama-pdf-extract` to rely entirely on Directus services
- update TypeScript types for `FilesService` and `AssetsService`

## Testing
- `npm run build` *(fails: directus-extension not found)*